### PR TITLE
Update TravisCI Script to fix the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,18 @@
 language: python
 python:
   - "2.7"
-  - "3.2"
   - "3.3"
   - "3.4"
   - "pypy"
-# command to install dependencies
+
+# Install test dependencies. TravisCI gives us nose, mock, and pytest by default
 install:
-  - "pip install coveralls --use-mirrors"
-  - "pip install nose --use-mirrors"
-  - "pip install mock --use-mirrors"
-# command to run tests
+  - pip install coveralls
+  - pip install -r requirements.txt
+
 script:
-#  - "python setup.py nosetests --cover-package=uiautomator --with-coverage --cover-erase"
   - "coverage run --source=uiautomator setup.py nosetests"
   - "python setup.py sdist"
-# after success
+
 after_success:
   coveralls


### PR DESCRIPTION
Removed python 3.2 as it isn't supported by latest coveragepy
https://github.com/nedbat/coveragepy/issues/15

Also did a couple small updates to the dependency management.

Considered adding python versions 3.5 and 3.6 but we are getting mock failures in the server start test. Will consider fixing the test and expanding coverage to include these versions as the next priority. I wanted to keep this first PR fairly atomic.