### PR TITLE
Make start timeout work properly.

### DIFF
--- a/uiautomator/__init__.py
+++ b/uiautomator/__init__.py
@@ -474,10 +474,13 @@ class AutomatorServer(object):
         self.uiautomator_process = self.adb.cmd(*cmd)
         self.adb.forward(self.local_port, self.device_port)
 
-        while not self.alive and timeout > 0:
-            time.sleep(0.1)
-            timeout -= 0.1
-        if not self.alive:
+        step_secs = 0.1
+        expiration_time = time.time() + timeout
+        while time.time() < expiration_time:
+            if self.alive:
+                break
+            time.sleep(step_secs)
+        else:
             raise IOError("RPC server not started!")
 
     def ping(self):


### PR DESCRIPTION
self.alive is an RPC call, which can take a long time (e.g. 45s) if there are problems with communicating to server.
Previously the loop was being executed exactly timeout * 10 times before timing out, resulting in 450s timeout instead of the requested value.
Now it is executed only until current timestamp is larger or equal the pre-calculated expiration time.