### PR TITLE
Explicitly start instrumentation only for Stub.

### DIFF
--- a/uiautomator/__init__.py
+++ b/uiautomator/__init__.py
@@ -469,6 +469,7 @@ class AutomatorServer(object):
         else:
             self.install()
             cmd = ["shell", "am", "instrument", "-w",
+                   "-e", "class", "com.github.uiautomator.stub.Stub",
                    "com.github.uiautomator.test/android.support.test.runner.AndroidJUnitRunner"]
 
         self.uiautomator_process = self.adb.cmd(*cmd)


### PR DESCRIPTION
Before the test name was not specified, which resulted in both test classes starting
(ApplicationTest and Stub), but only Stub is actually needed.