### PR TITLE
Newer pip does not have --use-mirrors option.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ python:
   - "pypy"
 # command to install dependencies
 install:
-  - "pip install coveralls --use-mirrors"
-  - "pip install nose --use-mirrors"
-  - "pip install mock --use-mirrors"
+  - "pip install coveralls"
+  - "pip install nose"
+  - "pip install mock"
 # command to run tests
 script:
 #  - "python setup.py nosetests --cover-package=uiautomator --with-coverage --cover-erase"


### PR DESCRIPTION
This is causing the travis failures.