### PR TITLE
Fix missing sdk_version function call in __init__

### DIFF
--- a/uiautomator/__init__.py
+++ b/uiautomator/__init__.py
@@ -472,7 +472,7 @@ class AutomatorServer(object):
                 files,
                 ["-c", "com.github.uiautomatorstub.Stub"]
             ))
-        elif self.sdk_version >= 28:
+        elif self.sdk_version() >= 28:
             self.install_androidx()
             cmd = ["shell", "am", "instrument", "-w",
                    "com.github.uiautomator.test/androidx.test.runner.AndroidJUnitRunner"]           


### PR DESCRIPTION
Fix the missing sdk_version function call in __init__.py that is blocking initialization in uiautomator 1.0.1.

https://github.com/xiaocong/uiautomator/issues/295