### PR TITLE
docs: fix simple typo, listenning -> listening

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ d(text="Clock").click()
 
 - Speficy the adb server host and port running on other computer
 
-    Although adb supports `-a` option since SDK 4.3, but now it has a bug on it. The only way to start adb server listenning on all interfaces instead of localhost, is `adb -a -P 5037 fork-server server &`
+    Although adb supports `-a` option since SDK 4.3, but now it has a bug on it. The only way to start adb server listening on all interfaces instead of localhost, is `adb -a -P 5037 fork-server server &`
 
   ```python
   from uiautomator import Device


### PR DESCRIPTION
There is a small typo in README.md.

Should read `listening` rather than `listenning`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md