### PR TITLE
Fix formatting in __init__.py

### DIFF
--- a/uiautomator/__init__.py
+++ b/uiautomator/__init__.py
@@ -403,12 +403,12 @@ class AutomatorServer(object):
     def install(self):
         base_dir = os.path.dirname(__file__)
         for apk in self.__apk_files:
-            self.adb.cmd("install", "-r -t", os.path.join(base_dir, apk)).wait()
+            self.adb.cmd("install", "-r", "-t", os.path.join(base_dir, apk)).wait()
 
     def install_androidx(self):
         base_dir = os.path.dirname(__file__)
         for apk in self.__androidx_apk_files:
-            self.adb.cmd("install", "-r -t", os.path.join(base_dir, apk)).wait()
+            self.adb.cmd("install", "-r", "-t", os.path.join(base_dir, apk)).wait()
 
     @property
     def jsonrpc(self):


### PR DESCRIPTION
IN line number 406 APK installation "-r -t" should be "-r", "-t". With "-r -t" it is not working in python 2.7 windows. Getting "RPC server not started error".